### PR TITLE
Updates

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -10,6 +10,8 @@ Credits to people and tools which helped out during the development of HybrProxy
 
 ### README Creator = [Leoo](https://github.com/heyitsleo)
 
+### Bug Tester = [Thororen](https://github.com/thororen1234)
+
 ## Libraries
 
 ### Main Proxy Libraries = [PrismarineJS](https://github.com/PrismarineJS)

--- a/README.md
+++ b/README.md
@@ -30,9 +30,7 @@ Suggested features are always being considered and sometimes added.
 
 To use it you need to have [NodeJS 16](https://nodejs.org/download/release/v16.20.0/) or [above](https://nodejs.org/en/download) installed for HybrProxy to build correctly.
 
-Linux is currently not working and needs to be fixed.
-
-MacOS and Windows can use 16+.
+Linux, MacOS, and Windows can use 16+.
 
 **This is a pre-release version and may contain bugs, as it's still being worked on.**
 

--- a/README.md
+++ b/README.md
@@ -30,6 +30,10 @@ Suggested features are always being considered and sometimes added.
 
 To use it you need to have [NodeJS 16](https://nodejs.org/download/release/v16.20.0/) or [above](https://nodejs.org/en/download) installed for HybrProxy to build correctly.
 
+Linux can use 16 only.
+Macos can use 16+.
+Windows can use 16+.
+
 **This is a pre-release version and may contain bugs, as it's still being worked on.**
 
 ## 📝 Building from Source

--- a/README.md
+++ b/README.md
@@ -32,9 +32,7 @@ To use it you need to have [NodeJS 16](https://nodejs.org/download/release/v16.2
 
 Linux is currently not working and needs to be fixed.
 
-Macos can use 16+.
-
-Windows can use 16+.
+MacOS and Windows can use 16+.
 
 **This is a pre-release version and may contain bugs, as it's still being worked on.**
 

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ At the root of the project (or in the same directory as the executable) create a
 ```jsonc
 {
   "apiKey": "API KEY HERE", // To get an api key, head to https://developer.hypixel.net/ and log in with your Hypixel Forums Account.
-    // (NOTE: You need to create an app on the website. After that, you can click create API key and enter that here)
+    // (NOTE: You need to create an app on the website. We suggest using the personal option. After that, you can click create API key and enter that here)
   "server": {
     // Change this to the server you are trying to connect, by default it will be set as hypixel.
     // (NOTE: Most other servers will not work)

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ Go to HybrProxy/dashboard/build. You should then see the specific package for th
 
 You will still need console for issues within the code to either report or solve yourself.
 
-### Arguments for console
+### Arguments
 
 HybrProxy supports the following arguments:
 

--- a/README.md
+++ b/README.md
@@ -28,9 +28,9 @@ Suggested features are always being considered and sometimes added.
 
 ### ⚠️ Requirements
 
-To use it you need to have [NodeJS 16](https://nodejs.org/download/release/v16.20.0/) installed.
+To use it you need to have [NodeJS 16](https://nodejs.org/download/release/v16.20.0/) or [above](https://nodejs.org/en/download) installed for HybrProxy to build correctly.
 
-**The version may contain bugs, as it's not fully released!**
+**This is a pre-release version and may contain bugs, as it's still being worked on.**
 
 ## 📝 Building from Source
 
@@ -55,7 +55,7 @@ $ npm run build
 
 ## Configuration ⚙️
 
-At the root of the project (or in the same directory as the executable) create a `config.jsonc` file with the following content:
+At the root of the project rename `config.example.jsonc` to `config.jsonc`. It should contain the following:
 
 ```jsonc
 {
@@ -94,7 +94,13 @@ At the root of the project (or in the same directory as the executable) create a
 $ npm start
 ```
 
-### Arguments
+### Starting without console
+
+Go to HybrProxy/dashboard/build. You should then see the specific package for the operating system you built HybrProxy on. It will end with exe/AppImage/dmg. Run the package and HybrProxy will install and all you will need to do is run it.
+
+You will still need console for issues within the code to either report or solve yourself.
+
+### Arguments for console
 
 HybrProxy supports the following arguments:
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,9 @@ Suggested features are always being considered and sometimes added.
 To use it you need to have [NodeJS 16](https://nodejs.org/download/release/v16.20.0/) or [above](https://nodejs.org/en/download) installed for HybrProxy to build correctly.
 
 Linux can use 16 only.
+
 Macos can use 16+.
+
 Windows can use 16+.
 
 **This is a pre-release version and may contain bugs, as it's still being worked on.**

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Suggested features are always being considered and sometimes added.
 
 To use it you need to have [NodeJS 16](https://nodejs.org/download/release/v16.20.0/) or [above](https://nodejs.org/en/download) installed for HybrProxy to build correctly.
 
-Linux can use 16 only.
+Linux is currently not working and needs to be fixed.
 
 Macos can use 16+.
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,8 @@ At the root of the project (or in the same directory as the executable) create a
 
 ```jsonc
 {
-  "apiKey": "API KEY HERE", // Connect to hypixel.net and do "/api new" and paste the API key here.
+  "apiKey": "API KEY HERE", // To get an api key, head to https://developer.hypixel.net/ and log in with your Hypixel Forums Account.
+    // (NOTE: You need to create an app on the website. After that, you can click create API key and enter that here)
   "server": {
     // Change this to the server you are trying to connect, by default it will be set as hypixel.
     // (NOTE: Most other servers will not work)

--- a/config.example.jsonc
+++ b/config.example.jsonc
@@ -1,5 +1,6 @@
 {
-  "apiKey": "API KEY HERE", // Connect to hypixel.net and do "/api new" and paste the API key here.
+  "apiKey": "API KEY HERE", // To get an api key, head to https://developer.hypixel.net/ and log in with your Hypixel Forums Account.
+    // (NOTE: You need to create an app on the website. We suggest using the personal option. After that, you can click create API key and enter that here)
   "server": {
     // Change this to the server you are trying to connect, by default it will be set as hypixel.
     // (NOTE: Most other servers will not work)

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -9,7 +9,11 @@
     "serve": "npm run setupCWD && vue-cli-service electron:serve",
     "postinstall": "npm run setupCWD"
   },
-  "author": "",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/HybrisMC/HybrProxy.git"
+  },
+  "author": "TBHGodPro",
   "license": "ISC",
   "dependencies": {
     "vue": "^3.2.47",

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -1,5 +1,4 @@
 const { execSync } = require('child_process');
-const { platform } = require('process');
 
 function run(executable, params = []) {
   execSync(`${executable} ${params.join(' ')}`, {
@@ -15,30 +14,16 @@ if (!process.argv.includes('--noDashboard')) {
   console.log('info: building dashboard 🌐');
 
   const nodeVersion = parseInt(process.version.split('.')[0].substring(1));
-  
+
   if (nodeVersion < 16)
     throw new Error('You must use Node 16 or higher to build dashboard!');
   if (nodeVersion > 16) console.log('fix: Setting OpenSSL Provider 🐛');
-  
-  if (process.platform === "win32") run(
-    nodeVersion > 16
-      ? 'cd dashboard && set NODE_OPTIONS=--openssl-legacy-provider && npm run build'
-      : 'cd dashboard && npm run build'
-  );
-  
-  if (process.platform === "darwin") run(
-    nodeVersion > 16
-      ? 'cd dashboard && export NODE_OPTIONS=--openssl-legacy-provider && npm run build'
-      : 'cd dashboard && npm run build'
-  );
-  
-  if (process.platform === "linux") run(
-    nodeVersion > 16
-      ? 'cd dashboard && export NODE_OPTIONS=--openssl-legacy-provider && npm run build'
-      : 'cd dashboard && npm run build'
-  );
 
-
+  run(
+    nodeVersion > 16
+      ? 'cd dashboard && NODE_OPTIONS=--openssl-legacy-provider npm run build'
+      : 'cd dashboard && npm run build'
+  );
 }
 
 console.log('\ninfo: build successful! 🎉\n -> Run the app using `npm start`');

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -1,5 +1,5 @@
 const { execSync } = require('child_process');
-import { platform } from 'node:process';
+const { platform } = require('process');
 
 function run(executable, params = []) {
   execSync(`${executable} ${params.join(' ')}`, {

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -31,7 +31,7 @@ if (!process.argv.includes('--noDashboard')) {
   );
   if (process.platform === "linux") run(
     nodeVersion > 16
-      ? 'cd dashboard && NODE_OPTIONS=--openssl-legacy-provider npm run build'
+      ? 'cd dashboard && export NODE_OPTIONS=--openssl-legacy-provider && npm run build'
       : 'cd dashboard && npm run build'
   );
 }

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -28,13 +28,13 @@ if (!process.argv.includes('--noDashboard')) {
   );
   var isMac = process.platform === "darwin";
   if (isMac === true) run(
-    nodeVedsion > 16
+    nodeVersion > 16
       ? 'cd dashboard && export NODE_OPTIONS=--openssl-legacy-provider && npm run build'
       : 'cd dashboard && npm run build'
   );
   var isLinux = process.platform === "linux";
   if (isLinux === true) run(
-    nodeVedsion > 16
+    nodeVersion > 16
       ? 'cd dashboard && export NODE_OPTIONS=--openssl-legacy-provider && npm run build'
       : 'cd dashboard && npm run build'
   );

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -25,14 +25,12 @@ if (!process.argv.includes('--noDashboard')) {
       ? 'cd dashboard && set NODE_OPTIONS=--openssl-legacy-provider && npm run build'
       : 'cd dashboard && npm run build'
   );
-  
   if (process.platform === "darwin") run(
     nodeVersion > 16
       ? 'cd dashboard && NODE_OPTIONS=--openssl-legacy-provider npm run build'
       : 'cd dashboard && npm run build'
   );
   // do your thing for linux skull
-  
 }
 
 console.log('\ninfo: build successful! 🎉\n -> Run the app using `npm start`');

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -29,7 +29,11 @@ if (!process.argv.includes('--noDashboard')) {
       ? 'cd dashboard && NODE_OPTIONS=--openssl-legacy-provider npm run build'
       : 'cd dashboard && npm run build'
   );
-  // do your thing for linux skull
+  if (process.platform === "linux") run(
+    nodeVersion > 16
+      ? 'cd dashboard && NODE_OPTIONS=--openssl-legacy-provider npm run build'
+      : 'cd dashboard && npm run build'
+  );
 }
 
 console.log('\ninfo: build successful! 🎉\n -> Run the app using `npm start`');

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -19,21 +19,20 @@ if (!process.argv.includes('--noDashboard')) {
   if (nodeVersion < 16)
     throw new Error('You must use Node 16 or higher to build dashboard!');
   if (nodeVersion > 16) console.log('fix: Setting OpenSSL Provider 🐛');
-
-  var isWin = process.platform === "win32";
-  if (isWin === true) run(
+  
+  if (process.platform === "win32") run(
     nodeVersion > 16
       ? 'cd dashboard && set NODE_OPTIONS=--openssl-legacy-provider && npm run build'
       : 'cd dashboard && npm run build'
   );
-  var isMac = process.platform === "darwin";
-  if (isMac === true) run(
+  
+  if (process.platform === "darwin") run(
     nodeVersion > 16
       ? 'cd dashboard && export NODE_OPTIONS=--openssl-legacy-provider && npm run build'
       : 'cd dashboard && npm run build'
   );
-  var isLinux = process.platform === "linux";
-  if (isLinux === true) run(
+  
+  if (process.platform === "linux") run(
     nodeVersion > 16
       ? 'cd dashboard && export NODE_OPTIONS=--openssl-legacy-provider && npm run build'
       : 'cd dashboard && npm run build'

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -1,4 +1,5 @@
 const { execSync } = require('child_process');
+const { platform } = require('process');
 
 function run(executable, params = []) {
   execSync(`${executable} ${params.join(' ')}`, {
@@ -19,11 +20,19 @@ if (!process.argv.includes('--noDashboard')) {
     throw new Error('You must use Node 16 or higher to build dashboard!');
   if (nodeVersion > 16) console.log('fix: Setting OpenSSL Provider 🐛');
 
-  run(
+  if (process.platform === "win32") run(
+    nodeVersion > 16
+      ? 'cd dashboard && set NODE_OPTIONS=--openssl-legacy-provider && npm run build'
+      : 'cd dashboard && npm run build'
+  );
+  
+  if (process.platform === "darwin") run(
     nodeVersion > 16
       ? 'cd dashboard && NODE_OPTIONS=--openssl-legacy-provider npm run build'
       : 'cd dashboard && npm run build'
   );
+  // do your thing fof linux skull
+  
 }
 
 console.log('\ninfo: build successful! 🎉\n -> Run the app using `npm start`');

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -1,4 +1,5 @@
 const { execSync } = require('child_process');
+import { platform } from 'node:process';
 
 function run(executable, params = []) {
   execSync(`${executable} ${params.join(' ')}`, {
@@ -14,16 +15,31 @@ if (!process.argv.includes('--noDashboard')) {
   console.log('info: building dashboard 🌐');
 
   const nodeVersion = parseInt(process.version.split('.')[0].substring(1));
-
+  
   if (nodeVersion < 16)
     throw new Error('You must use Node 16 or higher to build dashboard!');
   if (nodeVersion > 16) console.log('fix: Setting OpenSSL Provider 🐛');
 
-  run(
+  var isWin = process.platform === "win32";
+  if (isWin === true) run(
     nodeVersion > 16
-      ? 'cd dashboard && NODE_OPTIONS=--openssl-legacy-provider npm run build'
+      ? 'cd dashboard && set NODE_OPTIONS=--openssl-legacy-provider && npm run build'
       : 'cd dashboard && npm run build'
   );
+  var isMac = process.platform === "darwin";
+  if (isMac === true) run(
+    nodeVedsion > 16
+      ? 'cd dashboard && export NODE_OPTIONS=--openssl-legacy-provider && npm run build'
+      : 'cd dashboard && npm run build'
+  );
+  var isLinux = process.platform === "linux";
+  if (isLinux === true) run(
+    nodeVedsion > 16
+      ? 'cd dashboard && export NODE_OPTIONS=--openssl-legacy-provider && npm run build'
+      : 'cd dashboard && npm run build'
+  );
+
+
 }
 
 console.log('\ninfo: build successful! 🎉\n -> Run the app using `npm start`');

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -31,7 +31,7 @@ if (!process.argv.includes('--noDashboard')) {
       ? 'cd dashboard && NODE_OPTIONS=--openssl-legacy-provider npm run build'
       : 'cd dashboard && npm run build'
   );
-  // do your thing fof linux skull
+  // do your thing for linux skull
   
 }
 

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -1,5 +1,4 @@
 const { execSync } = require('child_process');
-const { platform } = require('process');
 
 function run(executable, params = []) {
   execSync(`${executable} ${params.join(' ')}`, {


### PR DESCRIPTION
I updated the readme to explain starting without console and fixed some other outdated lines.

For the config I just updated the way to get the API key.

Patch for windows node versions so they work aswell as added the MacOS node versions so that still works didn't do the Linux version as you said.

The it works trust is the only build.js patch that matters.
The config.example.jsonc should only have one update.
The readme was updated as we went along with these commits you don't have to read them all.